### PR TITLE
fix(auth): Resolve login security vulnerability

### DIFF
--- a/src/main/java/com/deocoe/springbootjwtauthapi/controller/AuthController.java
+++ b/src/main/java/com/deocoe/springbootjwtauthapi/controller/AuthController.java
@@ -4,13 +4,15 @@ import com.deocoe.springbootjwtauthapi.model.Usuario;
 import com.deocoe.springbootjwtauthapi.security.JwtUtil;
 import com.deocoe.springbootjwtauthapi.service.UsuarioService;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.Map;
-import java.util.Optional;
 
 @RestController
 @RequestMapping("/auth")
@@ -18,8 +20,11 @@ public class AuthController {
 
     private final UsuarioService usuarioService;
 
-    public AuthController(UsuarioService usuarioService) {
+    private final AuthenticationManager authenticationManager;
+
+    public AuthController(UsuarioService usuarioService, AuthenticationManager authenticationManager) {
         this.usuarioService = usuarioService;
+        this.authenticationManager = authenticationManager;
     }
 
     @PostMapping("/register")
@@ -30,11 +35,19 @@ public class AuthController {
 
     @PostMapping("/login")
     public ResponseEntity<?> login(@RequestBody Map<String, String> request) {
-        Optional<Usuario> usuario = usuarioService.buscarPorUsername(request.get("username"));
-        if(usuario.isPresent() && usuario.get().getPassword().equals(request.get("password"))) {
-            String token  = JwtUtil.generateToken(usuario.get().getUsername());
+        try {
+            UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(
+                    request.get("username"),
+                    request.get("password")
+            );
+
+            authenticationManager.authenticate(authToken);
+
+            String token = JwtUtil.generateToken(request.get("username"));
             return ResponseEntity.ok(Map.of("token", token));
+
+        } catch (BadCredentialsException e) {
+            return ResponseEntity.status(401).body("Credenciais Inválidas");
         }
-        return ResponseEntity.status(401).body("Credenciais Inválidas");
     }
 }

--- a/src/main/java/com/deocoe/springbootjwtauthapi/security/SecurityConfig.java
+++ b/src/main/java/com/deocoe/springbootjwtauthapi/security/SecurityConfig.java
@@ -10,6 +10,7 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
@@ -37,10 +38,17 @@ public class SecurityConfig {
     }
 
     @Bean
-    public AuthenticationManager authenticationManager() {
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(
+            UserDetailsService userDetailsService,
+            PasswordEncoder passwordEncoder) {
         DaoAuthenticationProvider authProvider = new DaoAuthenticationProvider();
         authProvider.setUserDetailsService(userDetailsService);
-        authProvider.setPasswordEncoder(new BCryptPasswordEncoder());
+        authProvider.setPasswordEncoder(passwordEncoder);
         return new ProviderManager(authProvider);
     }
 }

--- a/src/main/java/com/deocoe/springbootjwtauthapi/service/UsuarioService.java
+++ b/src/main/java/com/deocoe/springbootjwtauthapi/service/UsuarioService.java
@@ -1,9 +1,7 @@
 package com.deocoe.springbootjwtauthapi.service;
 
-
 import com.deocoe.springbootjwtauthapi.model.Usuario;
 import com.deocoe.springbootjwtauthapi.repository.UsuarioRepository;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
@@ -15,9 +13,9 @@ public class UsuarioService {
     private final UsuarioRepository usuarioRepository;
     private final PasswordEncoder passwordEncoder;
 
-    public UsuarioService(UsuarioRepository usuarioRepository) {
+    public UsuarioService(UsuarioRepository usuarioRepository, PasswordEncoder passwordEncoder) {
         this.usuarioRepository = usuarioRepository;
-        this.passwordEncoder = new BCryptPasswordEncoder();
+        this.passwordEncoder = passwordEncoder;
     }
 
     public Usuario registrarUsuario(String username, String password) {


### PR DESCRIPTION
Delegate password validation to AuthenticationManager, removing manual plain-text password comparison. This change also centralizes the PasswordEncoder as a single bean.

Closes #1